### PR TITLE
fix: Fix game crash related to MacroChain "/nextmacro"

### DIFF
--- a/MacroMate/Extensions/Dalamud/Macros/VanillaMacroManager.cs
+++ b/MacroMate/Extensions/Dalamud/Macros/VanillaMacroManager.cs
@@ -96,6 +96,12 @@ public unsafe class VanillaMacroManager : IDisposable {
                     continue;
                 }
 
+                if (encoded.Length > 0 && line.TextValue.StartsWith("/nextmacro"))
+                {
+                    macro.Lines[index].Clear();
+                    continue;
+                }
+                
                 fixed (byte* encodedPtr = encoded) {
                     macro.Lines[index].SetString(encodedPtr);
                 }


### PR DESCRIPTION
# **Version**
v1.0.22.0

# **Bug Description**
Run Macro in MacroMate UI with a macro longer enough to split into multiple macro or have any line with "/nextmacro" with MacroChain enable will cause game crash with Access Violation Exception.

# **Step Producing*
1. Create new Macro
2. Use Macro in **Example** section as Macro content
3. Run macro on MacroMate UI
4. Profit

# **Macro**

```
/nextmacro
```

```
/echo 1
/echo 2
/echo 3
/echo 4
/echo 5
/echo 6
/echo 7
/echo 8
/echo 9
/echo 10
/echo 11
/echo 12
/echo 13
/echo 14
/echo 15
/echo 16
/echo 17
/echo 18
/echo 19
/echo 20
```